### PR TITLE
Refactors DevtoolsEvent to support multiple top level events

### DIFF
--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -1,24 +1,20 @@
 pub mod runtime;
 
-pub use runtime::console::ConsoleEvent;
-pub use runtime::exception::ExceptionEvent;
+pub use runtime::RuntimeEvent;
 
 use std::fmt;
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "method", content = "params")]
+#[serde(untagged)]
+#[non_exhaustive]
 pub enum DevtoolsEvent {
-    #[serde(rename = "Runtime.consoleAPICalled")]
-    ConsoleAPICalled(ConsoleEvent),
-    #[serde(rename = "Runtime.exceptionThrown")]
-    ExceptionThrown(ExceptionEvent),
+    Runtime(RuntimeEvent),
 }
 
 impl fmt::Display for DevtoolsEvent {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match &self {
-            DevtoolsEvent::ConsoleAPICalled(event) => write!(f, "{}", event),
-            DevtoolsEvent::ExceptionThrown(event) => write!(f, "{}", event),
+            DevtoolsEvent::Runtime(event) => write!(f, "{}", event),
         }
     }
 }

--- a/src/events/runtime/mod.rs
+++ b/src/events/runtime/mod.rs
@@ -1,3 +1,27 @@
 pub mod console;
 pub mod exception;
 pub mod remote_object;
+
+use console::ConsoleEvent;
+use exception::ExceptionEvent;
+
+use std::fmt;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "method", content = "params")]
+#[non_exhaustive]
+pub enum RuntimeEvent {
+    #[serde(rename = "Runtime.consoleAPICalled")]
+    ConsoleAPICalled(ConsoleEvent),
+    #[serde(rename = "Runtime.exceptionThrown")]
+    ExceptionThrown(ExceptionEvent),
+}
+
+impl fmt::Display for RuntimeEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self {
+            RuntimeEvent::ConsoleAPICalled(event) => write!(f, "{}", event),
+            RuntimeEvent::ExceptionThrown(event) => write!(f, "{}", event),
+        }
+    }
+}


### PR DESCRIPTION
`DevtoolsEvent` can now match on multiple top level devtools event types. For now, I only need RuntimeEvents, but in the future we will want to add ProfilerEvents. This PR makes that addition fairly straightforward and also includes `#[non_exhaustive]` tags so that devs using this library always handle the `_ => ` case so we can confidently make changes to our enums that won't break users' builds

Fixes #24