### PR TITLE
Added accessor type to RemoteObject

### DIFF
--- a/src/domain/runtime/type/remote_object/mod.rs
+++ b/src/domain/runtime/type/remote_object/mod.rs
@@ -6,7 +6,6 @@ use r#type::object::{ObjectPreview, Subtype};
 use r#type::Type;
 
 use serde::{Deserialize, Serialize};
-use serde_json;
 
 use console::style;
 
@@ -109,6 +108,7 @@ impl fmt::Display for RemoteObject {
                 }
                 disp
             }
+            Type::Accessor => self.display_object(),
         };
         write!(f, "{}", formatted)
     }

--- a/src/domain/runtime/type/remote_object/type/mod.rs
+++ b/src/domain/runtime/type/remote_object/type/mod.rs
@@ -16,6 +16,7 @@ pub enum Type {
     Symbol,
     Undefined,
     Function,
+    Accessor,
 }
 
 impl fmt::Display for Type {

--- a/src/domain/runtime/type/remote_object/type/object/property_preview.rs
+++ b/src/domain/runtime/type/remote_object/type/object/property_preview.rs
@@ -73,13 +73,13 @@ impl PropertyPreview {
                 }
                 Type::Accessor => {
                     let r#type = if let Some(subtype) = &self.subtype {
-                        format!("ttt{:?}", subtype)
+                        format!("{:?}", subtype)
                     } else {
                         "Object".to_string()
                     };
                     let mut value = format!("[{}]", r#type);
                     if cfg!(feature = "color") {
-                        value = format!("tpt{}", style(value).cyan())
+                        value = format!("tpt{}", style(value).red())
                     }
                     value
                 }

--- a/src/domain/runtime/type/remote_object/type/object/property_preview.rs
+++ b/src/domain/runtime/type/remote_object/type/object/property_preview.rs
@@ -71,6 +71,18 @@ impl PropertyPreview {
                         value.to_string()
                     }
                 }
+                Type::Accessor => {
+                    let r#type = if let Some(subtype) = &self.subtype {
+                        format!("ttt{:?}", subtype)
+                    } else {
+                        "Object".to_string()
+                    };
+                    let mut value = format!("[{}]", r#type);
+                    if cfg!(feature = "color") {
+                        value = format!("tpt{}", style(value).cyan())
+                    }
+                    value
+                }
             }
         } else {
             let mut disp = format!("[{} {}]", &self.r#type, &self.name);


### PR DESCRIPTION
The `RemoteObject` doesn't have a type `accessor` which I found a request to have resulting in the request being unable to deserialize. 