### PR TITLE
Revert "Added line and column number to ExceptionDetails"

### DIFF
--- a/src/domain/runtime/event/exception_thrown.rs
+++ b/src/domain/runtime/event/exception_thrown.rs
@@ -20,12 +20,11 @@ impl fmt::Display for Event {
 
         let line_number = self.exception_details.line_number;
         let column_number = self.exception_details.column_number;
-        let url = self.exception_details.url.to_owned();
 
         if let Some(description) = &self.exception_details.exception.description {
             disp = format!(
-                "{}\n{}\nat line: {} column: {} in {}",
-                disp, description, line_number, column_number, url
+                "{}\n{}\nat line: {} column: {}",
+                disp, description, line_number, column_number
             );
         };
         if cfg!(feature = "color") {

--- a/src/domain/runtime/event/exception_thrown.rs
+++ b/src/domain/runtime/event/exception_thrown.rs
@@ -17,15 +17,8 @@ pub struct Event {
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut disp = self.exception_details.text.to_string();
-
-        let line_number = self.exception_details.line_number;
-        let column_number = self.exception_details.column_number;
-
         if let Some(description) = &self.exception_details.exception.description {
-            disp = format!(
-                "{}\n{}\nat line: {} column: {}",
-                disp, description, line_number, column_number
-            );
+            disp = format!("{}\n{}", disp, description);
         };
         if cfg!(feature = "color") {
             disp = format!("{}", style(disp).red())

--- a/src/domain/runtime/type/exception_details.rs
+++ b/src/domain/runtime/type/exception_details.rs
@@ -3,12 +3,9 @@ use serde::{Deserialize, Serialize};
 /// Detailed information about exception (or error) that was thrown during script compilation or execution.
 /// See [ExceptionDetails](https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-ExceptionDetails)
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct ExceptionDetails {
     pub text: String,
     pub exception: Exception,
-    pub line_number: usize,
-    pub column_number: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/domain/runtime/type/exception_details.rs
+++ b/src/domain/runtime/type/exception_details.rs
@@ -9,7 +9,6 @@ pub struct ExceptionDetails {
     pub exception: Exception,
     pub line_number: usize,
     pub column_number: usize,
-    pub url: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Reverts EverlastingBugstopper/chrome-devtools-rs#46
The line and column numbers returned here seem incorrect. Probably should being using sourcemap